### PR TITLE
ci: add build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: ["dev"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Build
+        run: npm run build --if-present
+
+      - name: Test
+        run: npm test --if-present


### PR DESCRIPTION
Adds a standard CI workflow (build + tests if present). Auto-generated by the portfolio foundations sweep; merged only if the check is green.